### PR TITLE
Remove profile in pom saying we're swagger because we aren't swagger.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -297,7 +297,7 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
+<!--         <profile>
             <id>release-sign-artifacts</id>
             <activation>
                 <property>
@@ -322,7 +322,7 @@
                     </plugin>
                 </plugins>
             </build>
-        </profile>
+        </profile> -->
         <!-- Samples -->
         <profile>
             <id>android-client</id>


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

